### PR TITLE
Update remove_words.py

### DIFF
--- a/remove_words.py
+++ b/remove_words.py
@@ -16,7 +16,7 @@ print(stop_words)
 dataset = '20ng'
 
 doc_content_list = []
-f = open('data/corpus/' + dataset + '.txt', 'r')
+f = open('data/corpus/' + dataset + '.txt', 'r',encoding="utf8", errors='ignore')
 # f = open('data/wiki_long_abstracts_en_text.txt', 'r')
 for line in f.readlines():
     doc_content_list.append(line.strip())


### PR DESCRIPTION
Python tries to convert a byte-array (a bytes which it assumes to be a utf-8-encoded string) to a unicode string (str). This process of course is a decoding according to utf-8 rules. When it tries this, it encounters a byte sequence which is not allowed in utf-8-encoded strings (namely this 0xff at position 0).

I have updated the file with  it will strip out (ignore) the characters and return the string without them. 

`with open(path, encoding="utf8", errors='ignore') as f:
`